### PR TITLE
Basic ATG integration

### DIFF
--- a/common/highlands/GenModMesa.java
+++ b/common/highlands/GenModMesa.java
@@ -1,0 +1,18 @@
+package highlands;
+
+import java.util.Random;
+import ttftcuts.atg.api.IGenMod;
+
+
+public class GenModMesa implements IGenMod {
+	
+	@Override
+	public int modify(int height, Random random, double rawHeight) {
+		return height + 7;
+	}
+	
+	@Override
+	public double noiseFactor() {
+		return 10.0;
+	}
+}

--- a/common/highlands/HighlandsCompatibilityManager.java
+++ b/common/highlands/HighlandsCompatibilityManager.java
@@ -22,6 +22,9 @@ import powercrystals.minefactoryreloaded.api.FactoryRegistry;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
+import ttftcuts.atg.api.ATGBiomes;
+import ttftcuts.atg.api.ATGBiomes.BiomeType;
+import ttftcuts.atg.api.IGenMod;
 
 import static net.minecraftforge.common.BiomeDictionary.Type;
 
@@ -377,6 +380,61 @@ public class HighlandsCompatibilityManager{
 			FactoryRegistry.registerHarvestable((BlockHighlandsLeaves)b);
 		}
 
+	}
+	
+	public static void registerBiomesATG(){
+		//This is based heavily on the BoP code for integration, modified to work accordingly for Highlands.  Many thanks to them for doing the legwork.
+        
+        BiomeType land = BiomeType.LAND;
+        BiomeType coast = BiomeType.COAST;
+        BiomeType sea = BiomeType.SEA;
+        
+        ATGBiomes.addBiome(land, "Boreal Forest", HighlandsBiomes.tallPineForest, 1.0);
+        ATGBiomes.addBiome(land, "Desert", HighlandsBiomes.dunes, 1.0);
+        ATGBiomes.addBiome(land, "Forest", HighlandsBiomes.woodsMountains, 1.0);
+        ATGBiomes.addBiome(land, "Forest", HighlandsBiomes.autumnForest, 1.0);
+        ATGBiomes.addBiome(land, "Forest", HighlandsBiomes.redwoodForest, 1.0);
+        ATGBiomes.addBiome(land, "Forest", HighlandsBiomes.flyingMountains, 1.0); //modify
+        ATGBiomes.addBiome(land, "Gravel Beach", HighlandsBiomes.cliffs, 1.0);
+        ATGBiomes.addBiome(land, "Ice Plains", HighlandsBiomes.alps, 1.0);
+        ATGBiomes.addBiome(land, "Ice Plains", HighlandsBiomes.snowMountains, 1.0);
+        ATGBiomes.addBiome(land, "Ice Plains", HighlandsBiomes.glacier, 1.0);
+        ATGBiomes.addBiome(land, "Jungle", HighlandsBiomes.tropics, 1.0);
+        ATGBiomes.addBiome(land, "Jungle", HighlandsBiomes.rainforest, 1.0);
+        ATGBiomes.addBiome(land, "Mesa", HighlandsBiomes.outback, 1.0);
+        ATGBiomes.addBiome(land, "Mesa", HighlandsBiomes.badlands, 1.0);
+        ATGBiomes.addBiome(land, "Mesa", HighlandsBiomes.desertMountains, 1.0);
+        ATGBiomes.addBiome(land, "Ocean", HighlandsBiomes.tropicalIslands, 1.0);
+        ATGBiomes.addBiome(land, "Savanna", HighlandsBiomes.savannah, 1.0);
+        ATGBiomes.addBiome(land, "Savanna", HighlandsBiomes.sahel, 1.0);
+        ATGBiomes.addBiome(land, "Shrubland", HighlandsBiomes.meadow, 1.0);
+        ATGBiomes.addBiome(land, "Shrubland", HighlandsBiomes.shrubland, 1.0);
+        ATGBiomes.addBiome(land, "Steppe", HighlandsBiomes.highlandsb, 1.0);
+        ATGBiomes.addBiome(land, "Steppe", HighlandsBiomes.rockMountains, 1.0);
+        ATGBiomes.addBiome(land, "Steppe", HighlandsBiomes.steppe, 1.0);
+        ATGBiomes.addBiome(land, "Swamp", HighlandsBiomes.bog, 1.0);
+        ATGBiomes.addBiome(land, "Swamp", HighlandsBiomes.estuary, 1.0);
+        ATGBiomes.addBiome(land, "Taiga", HighlandsBiomes.pinelands, 1.0);
+        ATGBiomes.addBiome(land, "Tundra", HighlandsBiomes.tundra, 1.0);
+        ATGBiomes.addBiome(land, "Tundra", HighlandsBiomes.lowlands, 1.0);
+        ATGBiomes.addBiome(land, "Woodland", HighlandsBiomes.woodlands, 1.0);
+        ATGBiomes.addBiome(land, "Woodland", HighlandsBiomes.birchHills, 1.0);
+        ATGBiomes.addBiome(sea, "Deep Ocean", HighlandsBiomes.ocean2, 1.0);
+        
+        ATGBiomes.addSubBiome(BiomeGenBase.ocean, HighlandsBiomes.desertIsland, 1.0);
+        ATGBiomes.addSubBiome(BiomeGenBase.ocean, HighlandsBiomes.forestIsland, 1.0);
+        ATGBiomes.addSubBiome(BiomeGenBase.ocean, HighlandsBiomes.snowIsland, 1.0);
+        ATGBiomes.addSubBiome(BiomeGenBase.ocean, HighlandsBiomes.jungleIsland, 1.0);
+        ATGBiomes.addSubBiome(BiomeGenBase.ocean, HighlandsBiomes.windyIsland, 1.0);
+        ATGBiomes.addSubBiome(BiomeGenBase.ocean, HighlandsBiomes.rockIsland, 1.0);
+        ATGBiomes.addSubBiome(BiomeGenBase.ocean, HighlandsBiomes.volcanoIsland, 1.0);
+        ATGBiomes.addSubBiome(HighlandsBiomes.badlands, HighlandsBiomes.canyon, 1.0);
+        ATGBiomes.addSubBiome(HighlandsBiomes.woodsMountains, HighlandsBiomes.valley, 1.0);
+        ATGBiomes.addSubBiome(HighlandsBiomes.dunes, HighlandsBiomes.oasis, 1.0);
+        ATGBiomes.addSubBiome(HighlandsBiomes.savannah, HighlandsBiomes.mesa, 1.0); //modify
+        ATGBiomes.addGenMod(HighlandsBiomes.mesa, new GenModMesa());
+        ATGBiomes.addSubBiome(HighlandsBiomes.woodlands, HighlandsBiomes.baldHill, 1.0); //modify
+        ATGBiomes.addSubBiome(HighlandsBiomes.lowlands, HighlandsBiomes.lake, 1.0);
 	}
 
 }

--- a/common/highlands/HighlandsMain.java
+++ b/common/highlands/HighlandsMain.java
@@ -238,6 +238,17 @@ public class HighlandsMain {
 				e.printStackTrace();
 			}
 		}
+		
+		//ATG PostInit
+		if (Loader.isModLoaded("ATG")){
+			try {
+				HighlandsCompatibilityManager.registerBiomesATG();
+			}
+			catch( Exception e ) {
+				System.err.println("[Highlands] Failed to enable ATG compatibility because: ");
+				e.printStackTrace();
+			}
+		}
 	}
 	
 	

--- a/common/ttftcuts/atg/api/ATGAPI.java
+++ b/common/ttftcuts/atg/api/ATGAPI.java
@@ -1,0 +1,11 @@
+package ttftcuts.atg.api;
+
+import net.minecraft.world.World;
+
+public class ATGAPI {
+
+	public static boolean WorldIsATG(World world) {
+		return world.provider.terrainType.getWorldTypeName() == "ATG";
+	}
+	
+}

--- a/common/ttftcuts/atg/api/ATGBiomes.java
+++ b/common/ttftcuts/atg/api/ATGBiomes.java
@@ -1,0 +1,224 @@
+package ttftcuts.atg.api;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import ttftcuts.atg.api.events.*;
+
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraftforge.common.MinecraftForge;
+
+import com.google.common.base.Optional;
+
+public abstract class ATGBiomes {
+	
+	public static enum BiomeType { LAND, COAST, SEA }
+	
+	/**
+	 * Gets an ATG biome by name.
+	 * 
+	 * @param biomeName
+	 * 				The name of the biome you want to get.
+	 * 
+	 * @return the corresponding biome.
+	 */
+	public static BiomeGenBase getBiome(String biomeName) {
+		final ATGBiomeRequestEvent event = new ATGBiomeRequestEvent(biomeName);
+		MinecraftForge.EVENT_BUS.post(event);
+		if ( !event.biome.isPresent() ) {
+			return null;
+		}
+		return event.biome.get();
+	}
+	
+	/**
+	 * Gets a list of names corresponding to the Biome Groups which contain a specified biome.
+	 * 
+	 * @param biome
+	 * 			The biome you want to find groups for.
+	 * 
+	 * @return a list of names of containing Biome Groups.
+	 */
+	public static List<String> getGroupFromBiome(BiomeGenBase biome) {
+		final ATGBiomeGroupRequestEvent event = new ATGBiomeGroupRequestEvent(biome);
+		MinecraftForge.EVENT_BUS.post(event);
+		return event.groups;
+	}
+	
+
+	/**
+	 * Adds a new biome GROUP to ATG. Not something that would usually need to be used.
+	 * 
+	 * @param type
+	 * 			The biome type that this group belongs to. LAND, COAST or SEA.
+	 * 
+	 * @param name
+	 * 			The name of this group.
+	 * 
+	 * @param temp
+	 * 			Temperature value for this group. Same range as biome temperatures.
+	 * 
+	 * @param moisture
+	 * 			Moisture value for this group. Same range as biome rainfall.
+	 * 
+	 * @param height
+	 * 			Average height value for this group. Same range as biome heights.
+	 * 
+	 * @param minHeight
+	 * 			Minimum height to generate this group. Above this value, it will be skipped.
+	 * 
+	 * @param maxHeight
+	 * 			Maximum height to generate this group. Below this value, it will be skipped.
+	 * 
+	 * @param salt
+	 * 			Biome blob generation salt. Used to offset biome boundaries from other groups to avoid strange artifacts.
+	 */
+	public static void addBiomeGroup(BiomeType type, String name, double temp, double moisture, double height, double minHeight, double maxHeight, long salt) {
+		ATGBiomeGroupAddEvent event = new ATGBiomeGroupAddEvent(type, name, temp, moisture, height, minHeight, maxHeight, salt);
+		MinecraftForge.EVENT_BUS.post(event);
+		if ( event.response == ATGBiomeGroupAddEvent.ResponseType.FAILED ) {
+			// FAILED!
+		}
+	}
+	public static void addBiomeGroup(BiomeType type, String name, double temp, double moisture, double height, long salt) {
+		addBiomeGroup(type, name, temp, moisture, height, 0.0, 1.0, salt);
+	}
+	public static void addBiomeGroup(BiomeType type, String name, double temp, double moisture, double height) {
+		addBiomeGroup(type, name, temp, moisture, height, 0);
+	}
+	
+
+	/**
+	 * Modifies a biome group to make it more or less likely to be chosen by the generator.
+	 * Best used to ensure a height-constrained biome group generates in favour of an otherwise identically ranged group.
+	 * 
+	 * @param type
+	 * 			Group type for the second parameter. LAND, COAST or SEA.
+	 * 
+	 * @param name
+	 * 			Name of the group to modify.
+	 * 
+	 * @param modifier
+	 * 			Modifier value. Positive makes the group more likely to be picked. Very small values can have a large effect.
+	 */
+	public static void modGroupSuitability(BiomeType type, String name, double modifier) {
+		ATGBiomeGroupEvent event = new ATGBiomeGroupEvent( ATGBiomeGroupEvent.EventType.SUITABILITY, type, name, modifier );
+		MinecraftForge.EVENT_BUS.post(event);
+		if ( event.response == ATGBiomeGroupEvent.ResponseType.FAILED ) {
+			// FAILED!
+		}
+	}
+	
+	
+	/**
+	 * Register a biome with ATG.
+	 * 
+	 * @param type
+	 * 			Type of the biome group this biome will inhabit. LAND, COAST or SEA.
+	 * 
+	 * @param group
+	 * 			Name of the biome group this biome will inhabit.
+	 * 
+	 * @param biome
+	 * 			The biome to be registered.
+	 * 
+	 * @param weight
+	 * 			Generation weight for this biome. All vanilla biomes are weighted 1.0 except mushroom island.
+	 */
+	public static void addBiome(BiomeType type, String group, BiomeGenBase biome, double weight) {
+		ATGBiomeEvent event = new ATGBiomeEvent( type, group, biome, null, weight);
+		MinecraftForge.EVENT_BUS.post(event);
+	}
+	
+	
+	/**
+	 * Replace a biome in a group with a different biome.
+	 * 
+	 * @param type
+	 * 			Type of the target biome group. LAND, COAST or SEA.
+	 * 
+	 * @param group
+	 * 			Name of the target biome group.
+	 * 
+	 * @param toReplace
+	 * 			Biome to replace in the specified group.
+	 * 
+	 * @param replacement
+	 * 			Biome which will replace toReplace in the group.
+	 * 
+	 * @param weight
+	 * 			Generation weight for the replacement biome.
+	 */
+	public static void replaceBiome(BiomeType type, String group, BiomeGenBase toReplace, BiomeGenBase replacement, double weight) {
+		ATGBiomeEvent event = new ATGBiomeEvent( type, group, replacement, toReplace, weight );
+		MinecraftForge.EVENT_BUS.post(event);
+	}
+	
+	
+	/**
+	 * Add a sub-biome to a biome. Sub-biomes appear as smaller patches within their parent biome.
+	 * 
+	 * @param biome
+	 * 			Parent biome.
+	 * 
+	 * @param subBiome
+	 * 			Biome that will appear as a sub-biome.
+	 * 
+	 * @param weight
+	 * 			Generation weight for the sub-biome. The parent biome is always weighted at 1.0, so a 1.0 weight here with a single sub-biome would be a 50/50 split.
+	 */
+	public static void addSubBiome(BiomeGenBase biome, BiomeGenBase subBiome, double weight) {
+		ATGBiomeModEvent event = new ATGBiomeModEvent(ATGBiomeModEvent.EventType.SUBBIOME, biome, null, subBiome, weight);
+		MinecraftForge.EVENT_BUS.post(event);
+	}
+	
+	
+	/**
+	 * Add an IGenMod to a biome to modify how it generates.
+	 * 	
+	 * @param biome
+	 * 			Biome to attach the mod to.
+	 * 
+	 * @param mod
+	 * 			IGenMod object that will modify the biome.
+	 */
+	public static void addGenMod(BiomeGenBase biome, IGenMod mod) {
+		ATGBiomeModEvent event = new ATGBiomeModEvent(ATGBiomeModEvent.EventType.GENMOD, biome, mod, null, 0);
+		MinecraftForge.EVENT_BUS.post(event);
+	}
+	
+	/**
+	 * Get the IGenMod assigned to a biome, or Optional.absent if there isn't one.
+	 * 
+	 * @param biome
+	 * 			The biome to get the IGenMod for.
+	 * 
+	 * @return an Optional corresponding to the IGenMod for the biome, or Optional.absent.
+	 */
+	public static Optional<IGenMod> getGenMod(BiomeGenBase biome) {
+		ATGBiomeModRequestEvent event = new ATGBiomeModRequestEvent(biome);
+		MinecraftForge.EVENT_BUS.post(event);
+		return event.mod;
+	}
+	
+	
+	/**
+	 * Sets the rock parameters for a biome, to modify how ATG boulders generate there.
+	 * 	
+	 * @param biome
+	 * 			The biome to set rock propeties for.
+	 *  
+	 * @param rockChance
+	 * 			1 in rockChance chunks will contain a rock.
+	 * 
+	 * @param bigRockChance
+	 * 			1 in bigRockChance rocks will be large.
+	 * 
+	 * @param rocksPerChunk
+	 * 			rockChance will be checked rocksPerChunk times per chunk.
+	 */
+	public static void setBiomeRocks(BiomeGenBase biome, int rockChance, int bigRockChance, int rocksPerChunk) {
+		ATGBiomeRocksEvent event = new ATGBiomeRocksEvent(biome, rockChance, bigRockChance, rocksPerChunk);
+		MinecraftForge.EVENT_BUS.post(event);
+	}
+}

--- a/common/ttftcuts/atg/api/IGenMod.java
+++ b/common/ttftcuts/atg/api/IGenMod.java
@@ -1,0 +1,9 @@
+package ttftcuts.atg.api;
+
+import java.util.Random;
+
+public interface IGenMod {
+	public int modify( int height, Random random, double rawHeight );
+	
+	public double noiseFactor();
+}

--- a/common/ttftcuts/atg/api/events/ATGBiomeEvent.java
+++ b/common/ttftcuts/atg/api/events/ATGBiomeEvent.java
@@ -1,0 +1,29 @@
+package ttftcuts.atg.api.events;
+
+import ttftcuts.atg.api.ATGBiomes.BiomeType;
+
+import com.google.common.base.Optional;
+
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraftforge.event.Event;
+
+public class ATGBiomeEvent extends Event {
+
+	public static enum ResponseType { NONE, ADDED, REPLACED, BAD_GROUP, FAILED };
+	
+	public BiomeType type;
+	public ResponseType response;
+	public String group;
+	public BiomeGenBase biome;
+	public BiomeGenBase replaced;
+	public double weight;
+	
+	public ATGBiomeEvent(BiomeType type, String group, BiomeGenBase biome, BiomeGenBase replaced, double weight) {
+		this.type = type;
+		this.group = group;
+		this.biome = biome;
+		this.replaced = replaced;
+		this.weight = weight;
+		this.response = ResponseType.NONE;
+	}
+}

--- a/common/ttftcuts/atg/api/events/ATGBiomeGroupAddEvent.java
+++ b/common/ttftcuts/atg/api/events/ATGBiomeGroupAddEvent.java
@@ -1,0 +1,31 @@
+package ttftcuts.atg.api.events;
+
+import ttftcuts.atg.api.ATGBiomes.BiomeType;
+import net.minecraftforge.event.Event;
+
+public class ATGBiomeGroupAddEvent extends Event {
+
+	public static enum ResponseType { NONE, OK, FAILED };
+	
+	public BiomeType type;
+	public ResponseType response;
+	public String name;
+	public double temp;
+	public double moisture;
+	public double height;
+	public double minHeight;
+	public double maxHeight;
+	public long salt;
+
+	public ATGBiomeGroupAddEvent( BiomeType type, String name, double temp, double moisture, double height, double minHeight, double maxHeight, long salt) {
+		this.type = type;
+		this.name = name;
+		this.temp = temp;
+		this.moisture = moisture;
+		this.height = height;
+		this.minHeight = minHeight;
+		this.maxHeight = maxHeight;
+		this.salt = salt;
+		this.response = ResponseType.NONE;
+	}
+}

--- a/common/ttftcuts/atg/api/events/ATGBiomeGroupEvent.java
+++ b/common/ttftcuts/atg/api/events/ATGBiomeGroupEvent.java
@@ -1,0 +1,24 @@
+package ttftcuts.atg.api.events;
+
+import ttftcuts.atg.api.ATGBiomes.BiomeType;
+import net.minecraftforge.event.Event;
+
+public class ATGBiomeGroupEvent extends Event {
+
+	public static enum EventType { SUITABILITY };
+	public static enum ResponseType { NONE, OK, FAILED };
+	
+	public EventType type;
+	public BiomeType biomeType;
+	public ResponseType response;
+	public String name;
+	public double modifier;
+
+	public ATGBiomeGroupEvent( EventType type, BiomeType biomeType, String name, double modifier ) {
+		this.type = type;
+		this.biomeType = biomeType;
+		this.name = name;
+		this.modifier = modifier;
+		this.response = ResponseType.NONE;
+	}
+}

--- a/common/ttftcuts/atg/api/events/ATGBiomeGroupRequestEvent.java
+++ b/common/ttftcuts/atg/api/events/ATGBiomeGroupRequestEvent.java
@@ -1,0 +1,21 @@
+package ttftcuts.atg.api.events;
+
+import java.util.List;
+
+import ttftcuts.atg.api.IGenMod;
+
+import com.google.common.base.Optional;
+
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraftforge.event.Event;
+
+public class ATGBiomeGroupRequestEvent extends Event {
+
+	public BiomeGenBase biome;
+	public List<String> groups;
+	
+	public ATGBiomeGroupRequestEvent(BiomeGenBase biome) {
+		this.biome = biome;
+		this.groups = null;
+	}
+}

--- a/common/ttftcuts/atg/api/events/ATGBiomeModEvent.java
+++ b/common/ttftcuts/atg/api/events/ATGBiomeModEvent.java
@@ -1,0 +1,25 @@
+package ttftcuts.atg.api.events;
+
+import ttftcuts.atg.api.IGenMod;
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraftforge.event.Event;
+
+public class ATGBiomeModEvent extends Event {
+
+	public static enum EventType { GENMOD, SUBBIOME }
+	
+	public EventType type;
+	public BiomeGenBase biome;
+	public IGenMod mod;
+	public BiomeGenBase subBiome;
+	public double weight;
+	
+	public ATGBiomeModEvent( EventType type, BiomeGenBase biome, IGenMod mod, BiomeGenBase subBiome, double weight ) {
+		
+		this.type = type;
+		this.biome = biome;
+		this.subBiome = subBiome;
+		this.mod = mod;
+		this.weight = weight;
+	}
+}

--- a/common/ttftcuts/atg/api/events/ATGBiomeModRequestEvent.java
+++ b/common/ttftcuts/atg/api/events/ATGBiomeModRequestEvent.java
@@ -1,0 +1,19 @@
+package ttftcuts.atg.api.events;
+
+import ttftcuts.atg.api.IGenMod;
+
+import com.google.common.base.Optional;
+
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraftforge.event.Event;
+
+public class ATGBiomeModRequestEvent extends Event {
+
+	public BiomeGenBase biome;
+	public Optional<IGenMod> mod;
+	
+	public ATGBiomeModRequestEvent(BiomeGenBase biome) {
+		this.biome = biome;
+		this.mod = Optional.absent();
+	}
+}

--- a/common/ttftcuts/atg/api/events/ATGBiomeRequestEvent.java
+++ b/common/ttftcuts/atg/api/events/ATGBiomeRequestEvent.java
@@ -1,0 +1,17 @@
+package ttftcuts.atg.api.events;
+
+import com.google.common.base.Optional;
+
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraftforge.event.Event;
+
+public class ATGBiomeRequestEvent extends Event {
+
+	public String biomeName;
+	public Optional<BiomeGenBase> biome;
+	
+	public ATGBiomeRequestEvent(String biomeName) {
+		this.biomeName = biomeName;
+		this.biome = Optional.absent();
+	}
+}

--- a/common/ttftcuts/atg/api/events/ATGBiomeRocksEvent.java
+++ b/common/ttftcuts/atg/api/events/ATGBiomeRocksEvent.java
@@ -1,0 +1,19 @@
+package ttftcuts.atg.api.events;
+
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraftforge.event.Event;
+
+public class ATGBiomeRocksEvent extends Event {
+
+	public BiomeGenBase biome;
+	public int rockChance;
+	public int bigRockChance;
+	public int rocksPerChunk;
+	
+	public ATGBiomeRocksEvent( BiomeGenBase biome, int rockChance, int bigRockChance, int rocksPerChunk ) {
+		this.biome = biome;
+		this.rockChance = rockChance;
+		this.bigRockChance = bigRockChance;
+		this.rocksPerChunk = rocksPerChunk;
+	}
+}


### PR DESCRIPTION
This registers all biomes and sub-biomes with ATG (Alternate Terrain
Generation) and adds a basic IGenMod for the Mesa sub-biome.  All
registered biomes-and sub-biomes are weighted the same as vanilla biomes
(1.0).  The API is also included in full and is for ATG version 0.9.3.
